### PR TITLE
MTZ8302: onboard section control switchable: active/sleep

### DIFF
--- a/lib/aio_system/MachineProcessor.h
+++ b/lib/aio_system/MachineProcessor.h
@@ -85,6 +85,7 @@ public:
     
     // Section control helpers
     bool initializeSectionOutputs();
+    uint8_t SCOnBoadStatus();  // status of on board section control 0: sleep/not active, 1: active
     void setPinHigh(uint8_t pin);
     void setPinLow(uint8_t pin);
     void setPinPWM(uint8_t pin, uint16_t pwmValue);  // For Danfoss valve control


### PR DESCRIPTION
Sleep for onboard section control: no heartbeat, no scan reply, all onboard sections off

if external section control is connected via WiFi, onboard should be silent